### PR TITLE
[test] 분석 도메인 테스트 코드 구현

### DIFF
--- a/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/command/domain/repository/EmotionAnalysisRepository.java
+++ b/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/command/domain/repository/EmotionAnalysisRepository.java
@@ -3,8 +3,12 @@ package com.piveguyz.ondambackend.analysis.command.domain.repository;
 import com.piveguyz.ondambackend.analysis.command.domain.aggregate.EmotionAnalysis;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EmotionAnalysisRepository extends JpaRepository<EmotionAnalysis, Long> {
     void deleteByAnalysisId(Long analysisId);
 
     long countByEmotionId(Long id);
+
+    List<EmotionAnalysis> findByAnalysisId(Long analysisId);
 }

--- a/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/command/domain/repository/EmotionCategoryRepository.java
+++ b/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/command/domain/repository/EmotionCategoryRepository.java
@@ -3,6 +3,10 @@ package com.piveguyz.ondambackend.analysis.command.domain.repository;
 import com.piveguyz.ondambackend.analysis.command.domain.aggregate.EmotionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EmotionCategoryRepository extends JpaRepository<EmotionCategory, Long> {
     boolean existsByName(String name);
+
+    Optional<EmotionCategory> findByName(String oldName);
 }

--- a/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/query/controller/AnalysisQueryController.java
+++ b/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/query/controller/AnalysisQueryController.java
@@ -1,7 +1,7 @@
 package com.piveguyz.ondambackend.analysis.query.controller;
 
 import com.piveguyz.ondambackend.analysis.query.dto.AnalysisResultDTO;
-import com.piveguyz.ondambackend.analysis.query.service.AnalysisService;
+import com.piveguyz.ondambackend.analysis.query.service.AnalysisQueryService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,16 +13,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/analysis")
 @Slf4j
 public class AnalysisQueryController {
-    private final AnalysisService analysisService;
+    private final AnalysisQueryService analysisQueryService;
 
     @Autowired
-    public AnalysisQueryController(AnalysisService analysisService) {
-        this.analysisService = analysisService;
+    public AnalysisQueryController(AnalysisQueryService analysisQueryService) {
+        this.analysisQueryService = analysisQueryService;
     }
 
     @GetMapping("/{counselId}/analysis")
     public AnalysisResultDTO getAnalysisResult(@PathVariable Long counselId) {
-        return analysisService.getAnalysisResult(counselId);
+        return analysisQueryService.getAnalysisResult(counselId);
     }
 
 }

--- a/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/query/service/AnalysisQueryService.java
+++ b/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/query/service/AnalysisQueryService.java
@@ -2,6 +2,6 @@ package com.piveguyz.ondambackend.analysis.query.service;
 
 import com.piveguyz.ondambackend.analysis.query.dto.AnalysisResultDTO;
 
-public interface AnalysisService {
+public interface AnalysisQueryService {
     AnalysisResultDTO getAnalysisResult(Long counselId);
 }

--- a/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/query/service/AnalysisQueryServiceImpl.java
+++ b/ondam-backend/src/main/java/com/piveguyz/ondambackend/analysis/query/service/AnalysisQueryServiceImpl.java
@@ -8,12 +8,12 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Service("QueryAnalysisService")
-public class AnalysisServiceImpl implements AnalysisService {
+@Service
+public class AnalysisQueryServiceImpl implements AnalysisQueryService {
     private final AnalysisResultMapper analysisResultMapper;
 
     @Autowired
-    public AnalysisServiceImpl(AnalysisResultMapper analysisResultMapper) {
+    public AnalysisQueryServiceImpl(AnalysisResultMapper analysisResultMapper) {
         this.analysisResultMapper = analysisResultMapper;
     }
 

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/AnalysisCommandTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/AnalysisCommandTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @Transactional
-class AnalysisServiceImplTest {
+class AnalysisCommandTest {
 
     @Autowired
     AnalysisService analysisService;

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/AnalysisCommandTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/AnalysisCommandTest.java
@@ -1,0 +1,78 @@
+package com.piveguyz.ondambackend.analysis;
+
+import com.piveguyz.ondambackend.analysis.command.application.service.AnalysisService;
+import com.piveguyz.ondambackend.analysis.command.domain.aggregate.Emotion;
+import com.piveguyz.ondambackend.analysis.command.domain.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+class AnalysisServiceImplTest {
+
+    @Autowired
+    AnalysisService analysisService;
+
+    @Autowired
+    AnalysisRepository analysisRepository;
+
+    @Autowired
+    TroubleSummaryRepository troubleSummaryRepository;
+
+    @Autowired
+    EmotionAnalysisRepository emotionAnalysisRepository;
+
+    @Autowired
+    EffectiveStatementRepository effectiveStatementRepository;
+
+    @Autowired
+    ShortenedCounselRepository shortenedCounselRepository;
+
+    @Autowired
+    EmotionRepository emotionRepository;
+
+    @BeforeEach
+    void setupEmotions() {
+        List<String> emotionNames = List.of("불안", "우울");
+
+        for (String name : emotionNames) {
+            if (emotionRepository.findByName(name).isEmpty()) {
+                emotionRepository.save(Emotion.builder().name(name).build());
+            }
+        }
+    }
+
+    static Stream<Arguments> saveFromDbArgs() {
+        return Stream.of(Arguments.of(1L), Arguments.of(2L));
+    }
+
+    @ParameterizedTest
+    @DisplayName("dbTestJson으로 분석 결과 저장 테스트")
+    @MethodSource("saveFromDbArgs")
+    void saveFromDbTest(Long testCounselId) {
+        // when
+        analysisService.testSaveAnalysis(testCounselId);
+
+        // then
+        assertTrue(analysisRepository.findByCounselId(testCounselId).isPresent());
+        assertTrue(troubleSummaryRepository.findByAnalysisId(analysisRepository.findByCounselId(testCounselId).get().getId()).isPresent());
+
+        assertFalse(emotionAnalysisRepository.findByAnalysisId(analysisRepository.findByCounselId(testCounselId).get().getId()).isEmpty());
+
+        assertTrue(effectiveStatementRepository.findByAnalysisId(analysisRepository.findByCounselId(testCounselId).get().getId()).isPresent());
+
+        assertTrue(shortenedCounselRepository.findByAnalysisId(analysisRepository.findByCounselId(testCounselId).get().getId()).isPresent());
+    }
+}

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/AnalysisQueryTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/AnalysisQueryTest.java
@@ -1,0 +1,87 @@
+package com.piveguyz.ondambackend.analysis;
+
+import com.piveguyz.ondambackend.analysis.command.application.service.AnalysisService;
+import com.piveguyz.ondambackend.analysis.query.dto.*;
+import com.piveguyz.ondambackend.analysis.query.service.AnalysisQueryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class AnalysisQueryTest {
+
+    @Autowired
+    AnalysisService analysisService;
+
+    @Autowired
+    AnalysisQueryService analysisQueryService;
+
+    // 조회할 데이터 미리 넣어두기
+    @BeforeEach
+    void setUp() {
+        analysisService.testSaveAnalysis(1L);
+        analysisService.testSaveAnalysis(2L);
+    }
+
+    static Stream<Arguments> getAnalysisResultArgs() {
+        return Stream.of(
+                Arguments.of(1L),
+                Arguments.of(2L)
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("분석 결과 조회")
+    @MethodSource("getAnalysisResultArgs")
+    void getAnalysisResultTest(Long counselId) {
+        AnalysisResultDTO result = analysisQueryService.getAnalysisResult(counselId);
+
+        // then
+        assertNotNull(result);
+        assertNotNull(result.getTroubleSummary());
+        assertNotNull(result.getEffectiveStatement());
+        assertNotNull(result.getShortenedCounsel());
+        assertNotNull(result.getEmotionAnalysisList());
+        assertFalse(result.getEmotionAnalysisList().isEmpty());
+
+        // 출력
+        System.out.println("분석 ID: " + result.getId());
+        System.out.println("🧠 고민 요약:");
+        System.out.println("- 시기: " + result.getTroubleSummary().getPeriod());
+        System.out.println("- 장소: " + result.getTroubleSummary().getPlace());
+        System.out.println("- 상황: " + result.getTroubleSummary().getSituation());
+        System.out.println("- 이유: " + result.getTroubleSummary().getReason());
+        System.out.println("- 흐름: " + result.getTroubleSummary().getFlow());
+        System.out.println("- 결심: " + result.getTroubleSummary().getDetermination());
+
+        System.out.println("\n🎯 효과적 발화:");
+        System.out.println("- 내용: " + result.getEffectiveStatement().getContent());
+        System.out.println("- 반응: " + result.getEffectiveStatement().getResponse());
+        System.out.println("- 이유: " + result.getEffectiveStatement().getReason());
+        System.out.println("- 결과: " + result.getEffectiveStatement().getResult());
+
+        System.out.println("\n📄 상담 요약:");
+        System.out.println("- 정서 변화: " + result.getShortenedCounsel().getEmotionalChange());
+        System.out.println("- 인지: " + result.getShortenedCounsel().getCognitive());
+        System.out.println("- 행동: " + result.getShortenedCounsel().getBehavioral());
+        System.out.println("- 반응: " + result.getShortenedCounsel().getResponse());
+        System.out.println("- 추천: " + result.getShortenedCounsel().getRecommendedDirection());
+
+        System.out.println("\n💬 감정 분석 목록:");
+        for (EmotionAnalysisDTO ea : result.getEmotionAnalysisList()) {
+            System.out.println("- 감정: " + ea.getEmotion());
+            System.out.println("  근거: " + ea.getEvidence());
+            System.out.println("  이유: " + ea.getReason());
+        }
+    }
+}

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
@@ -77,7 +77,7 @@ public class EmotionCategoryCommandTest {
     @ParameterizedTest
     @DisplayName("감정 카테고리 삭제 테스트")
     @MethodSource("deleteCategoryArgs")
-    void testDeleteEmotionCategory(String name) {
+    void deleteEmotionCategoryTest(String name) {
         EmotionCategory existingCategory = emotionCategoryRepository.findByName(name).orElseThrow(() -> new IllegalArgumentException("삭제할 카테고리를 찾을 수 없습니다: " + name));
 
         emotionCategoryRepository.delete(existingCategory);

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
@@ -1,8 +1,5 @@
 package com.piveguyz.ondambackend.analysis;
 
-import com.piveguyz.ondambackend.analysis.command.application.dto.EmotionCategoryDTO;
-import com.piveguyz.ondambackend.analysis.command.application.service.EmotionCategoryService;
-import com.piveguyz.ondambackend.analysis.command.application.service.EmotionService;
 import com.piveguyz.ondambackend.analysis.command.domain.aggregate.EmotionCategory;
 import com.piveguyz.ondambackend.analysis.command.domain.repository.EmotionCategoryRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,12 +22,16 @@ public class EmotionCategoryCommandTest {
     @Autowired
     private EmotionCategoryRepository emotionCategoryRepository;
 
+    // 수정, 삭제를 위해 미리 넣어두기
+    @BeforeEach
+    void setup() {
+        emotionCategoryRepository.save(EmotionCategory.builder().name("긍정적 테스트").build());
+        emotionCategoryRepository.save(EmotionCategory.builder().name("부정적 테스트").build());
+    }
+
     // 감정 카테고리 등록 테스트
     static Stream<Arguments> createCategoryArgs() {
-        return Stream.of(
-                Arguments.of("행복"),
-                Arguments.of("슬픔")
-        );
+        return Stream.of(Arguments.of("중립/혼합 테스트"), Arguments.of("성장/회복 테스트"));
     }
 
     @ParameterizedTest
@@ -41,9 +42,7 @@ public class EmotionCategoryCommandTest {
             throw new IllegalArgumentException("이미 존재하는 감정 카테고리입니다: " + name);
         }
 
-        EmotionCategory newCategory = EmotionCategory.builder()
-                .name(name)
-                .build();
+        EmotionCategory newCategory = EmotionCategory.builder().name(name).build();
 
         emotionCategoryRepository.save(newCategory);
         assertTrue(emotionCategoryRepository.existsByName(name));
@@ -51,16 +50,10 @@ public class EmotionCategoryCommandTest {
 
 
     // 감정 카테고리 수정 테스트
-    @BeforeEach
-    void setup() {
-        emotionCategoryRepository.save(EmotionCategory.builder().name("기쁨").build());
-        emotionCategoryRepository.save(EmotionCategory.builder().name("희망").build());
-    }
-
     static Stream<Arguments> updateCategoryArgs() {
         return Stream.of(
-                Arguments.of("기쁨", "행복"),
-                Arguments.of("희망", "즐거움")
+                Arguments.of("긍정적 테스트", "대인관계 테스트"),
+                Arguments.of("부정적 테스트", "중립/혼합 테스트")
         );
     }
 
@@ -68,8 +61,7 @@ public class EmotionCategoryCommandTest {
     @DisplayName("감정 카테고리 수정 테스트")
     @MethodSource("updateCategoryArgs")
     void updateEmotionCategoryTest(String oldName, String newName) {
-        EmotionCategory existingCategory = emotionCategoryRepository.findByName(oldName)
-                .orElseThrow(() -> new IllegalArgumentException("기존 카테고리를 찾을 수 없습니다: " + oldName));
+        EmotionCategory existingCategory = emotionCategoryRepository.findByName(oldName).orElseThrow(() -> new IllegalArgumentException("기존 카테고리를 찾을 수 없습니다: " + oldName));
 
         existingCategory.updateName(newName);
         emotionCategoryRepository.save(existingCategory);
@@ -77,19 +69,16 @@ public class EmotionCategoryCommandTest {
         assertTrue(emotionCategoryRepository.existsByName(newName));
     }
 
+    // 감정 카테고리 삭제 테스트
     static Stream<Arguments> deleteCategoryArgs() {
-        return Stream.of(
-                Arguments.of("기쁨"),
-                Arguments.of("희망")
-        );
+        return Stream.of(Arguments.of("긍정적 테스트"), Arguments.of("부정적 테스트"));
     }
 
     @ParameterizedTest
     @DisplayName("감정 카테고리 삭제 테스트")
     @MethodSource("deleteCategoryArgs")
     void testDeleteEmotionCategory(String name) {
-        EmotionCategory existingCategory = emotionCategoryRepository.findByName(name)
-                .orElseThrow(() -> new IllegalArgumentException("삭제할 카테고리를 찾을 수 없습니다: " + name));
+        EmotionCategory existingCategory = emotionCategoryRepository.findByName(name).orElseThrow(() -> new IllegalArgumentException("삭제할 카테고리를 찾을 수 없습니다: " + name));
 
         emotionCategoryRepository.delete(existingCategory);
 

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
@@ -31,7 +31,10 @@ public class EmotionCategoryCommandTest {
 
     // 감정 카테고리 등록 테스트
     static Stream<Arguments> createCategoryArgs() {
-        return Stream.of(Arguments.of("중립/혼합 테스트"), Arguments.of("성장/회복 테스트"));
+        return Stream.of(
+                Arguments.of("중립/혼합 테스트"),
+                Arguments.of("성장/회복 테스트")
+        );
     }
 
     @ParameterizedTest
@@ -71,7 +74,9 @@ public class EmotionCategoryCommandTest {
 
     // 감정 카테고리 삭제 테스트
     static Stream<Arguments> deleteCategoryArgs() {
-        return Stream.of(Arguments.of("긍정적 테스트"), Arguments.of("부정적 테스트"));
+        return Stream.of(
+                Arguments.of("긍정적 테스트"),
+                Arguments.of("부정적 테스트"));
     }
 
     @ParameterizedTest

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCategoryCommandTest.java
@@ -1,0 +1,98 @@
+package com.piveguyz.ondambackend.analysis;
+
+import com.piveguyz.ondambackend.analysis.command.application.dto.EmotionCategoryDTO;
+import com.piveguyz.ondambackend.analysis.command.application.service.EmotionCategoryService;
+import com.piveguyz.ondambackend.analysis.command.application.service.EmotionService;
+import com.piveguyz.ondambackend.analysis.command.domain.aggregate.EmotionCategory;
+import com.piveguyz.ondambackend.analysis.command.domain.repository.EmotionCategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+@SpringBootTest
+@Transactional
+public class EmotionCategoryCommandTest {
+    @Autowired
+    private EmotionCategoryRepository emotionCategoryRepository;
+
+    // 감정 카테고리 등록 테스트
+    static Stream<Arguments> createCategoryArgs() {
+        return Stream.of(
+                Arguments.of("행복"),
+                Arguments.of("슬픔")
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("감정 카테고리 등록 테스트")
+    @MethodSource("createCategoryArgs")
+    void createEmotionCategoryTest(String name) {
+        if (emotionCategoryRepository.existsByName(name)) {
+            throw new IllegalArgumentException("이미 존재하는 감정 카테고리입니다: " + name);
+        }
+
+        EmotionCategory newCategory = EmotionCategory.builder()
+                .name(name)
+                .build();
+
+        emotionCategoryRepository.save(newCategory);
+        assertTrue(emotionCategoryRepository.existsByName(name));
+    }
+
+
+    // 감정 카테고리 수정 테스트
+    @BeforeEach
+    void setup() {
+        emotionCategoryRepository.save(EmotionCategory.builder().name("기쁨").build());
+        emotionCategoryRepository.save(EmotionCategory.builder().name("희망").build());
+    }
+
+    static Stream<Arguments> updateCategoryArgs() {
+        return Stream.of(
+                Arguments.of("기쁨", "행복"),
+                Arguments.of("희망", "즐거움")
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("감정 카테고리 수정 테스트")
+    @MethodSource("updateCategoryArgs")
+    void updateEmotionCategoryTest(String oldName, String newName) {
+        EmotionCategory existingCategory = emotionCategoryRepository.findByName(oldName)
+                .orElseThrow(() -> new IllegalArgumentException("기존 카테고리를 찾을 수 없습니다: " + oldName));
+
+        existingCategory.updateName(newName);
+        emotionCategoryRepository.save(existingCategory);
+
+        assertTrue(emotionCategoryRepository.existsByName(newName));
+    }
+
+    static Stream<Arguments> deleteCategoryArgs() {
+        return Stream.of(
+                Arguments.of("기쁨"),
+                Arguments.of("희망")
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("감정 카테고리 삭제 테스트")
+    @MethodSource("deleteCategoryArgs")
+    void testDeleteEmotionCategory(String name) {
+        EmotionCategory existingCategory = emotionCategoryRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("삭제할 카테고리를 찾을 수 없습니다: " + name));
+
+        emotionCategoryRepository.delete(existingCategory);
+
+        assertFalse(emotionCategoryRepository.existsByName(name), "카테고리가 정상적으로 삭제되지 않았습니다.");
+    }
+}

--- a/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCommandTest.java
+++ b/ondam-backend/src/test/java/com/piveguyz/ondambackend/analysis/EmotionCommandTest.java
@@ -1,0 +1,102 @@
+package com.piveguyz.ondambackend.analysis;
+
+import com.piveguyz.ondambackend.analysis.command.domain.aggregate.Emotion;
+import com.piveguyz.ondambackend.analysis.command.domain.repository.EmotionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+public class EmotionCommandTest {
+    @Autowired
+    private EmotionRepository emotionRepository;
+
+    // 수정, 삭제를 위해 미리 넣어두기
+    @BeforeEach
+    void setup() {
+        emotionRepository.save(Emotion.builder()
+                .name("기쁨 테스트")
+                .emotionCategoryId(1L)
+                .build());
+        emotionRepository.save(Emotion.builder()
+                .name("안도 테스트")
+                .emotionCategoryId(1L)
+                .build());
+    }
+
+    // 감정 등록 테스트
+    static Stream<Arguments> createEmotionArgs() {
+        return Stream.of(
+                Arguments.of("우울 테스트", 2L),
+                Arguments.of("슬픔 테스트", 2L)
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("감정 등록 테스트")
+    @MethodSource("createEmotionArgs")
+    void createEmotionTest(String name, Long emotionCategoryId) {
+        if (emotionRepository.existsByName(name)) {
+            throw new IllegalArgumentException("이미 존재하는 감정입니다: " + name);
+        }
+
+        Emotion newEmotion = Emotion.builder()
+                .name(name)
+                .emotionCategoryId(emotionCategoryId)
+                .build();
+
+        emotionRepository.save(newEmotion);
+        assertTrue(emotionRepository.existsByName(name));
+    }
+
+
+    // 감정 수정 테스트
+    static Stream<Arguments> updateEmotionArgs() {
+        return Stream.of(
+                Arguments.of("기쁨 테스트", "대인관계 테스트"),
+                Arguments.of("안도 테스트", "즐거움 테스트")
+        );
+    }
+
+    @ParameterizedTest
+    @DisplayName("감정 수정 테스트")
+    @MethodSource("updateEmotionArgs")
+    void updateEmotionTest(String oldName, String newName) {
+        Emotion existingEmotion = emotionRepository.findByName(oldName).
+                orElseThrow(() -> new IllegalArgumentException("기존 감정 정보를 찾을 수 없습니다: " + oldName));
+
+        // 감정 이름 수정
+        existingEmotion.update(newName, existingEmotion.getEmotionCategoryId());
+        emotionRepository.save(existingEmotion);
+
+        assertTrue(emotionRepository.existsByName(newName));
+    }
+
+    // 감정 삭제 테스트
+    static Stream<Arguments> deleteEmotionArgs() {
+        return Stream.of(Arguments.of("기쁨 테스트"), Arguments.of("안도 테스트"));
+    }
+
+    @ParameterizedTest
+    @DisplayName("감정 삭제 테스트")
+    @MethodSource("deleteEmotionArgs")
+    void deleteEmotionTest(String name) {
+        Emotion existingEmotion = emotionRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("삭제할 감정 정보를 찾을 수 없습니다: " + name));
+
+        emotionRepository.delete(existingEmotion);
+
+        assertFalse(emotionRepository.existsByName(name), "감정 정보가 정상적으로 삭제되지 않았습니다.");
+    }
+}


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스
- [x] 테스트

### 🔀 작업 브랜치
test/sh/analysis testcode

### #️⃣ 연관된 이슈
close #52


### 📝 변경 사항
- 감정 테이블 : 데이터 생성, 수정, 삭제 테스트 코드 구현
- 감정 카테고리 테이블 : 데이터 생성, 수정, 삭제 테스트 코드 구현
- 분석 테이블 : 테스트 json 등록, 조회 테스트 코드 구현


### 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분
- 감정과 감정 카테고리의 경우 gpt 프롬프트와 같아야해서 때문에 데이터가 고정으로 들어갑니다.
-> 혹시 더미 데이터와 겹쳐서 오류가 발생할까봐 뒤에 '테스트'라는 단어를 모두 붙였습니다.

### 📷 관련 스크린샷
![{53D64ED2-2E19-48FA-9B28-F29CD7F762E0}](https://github.com/user-attachments/assets/40486ecb-7faf-4f56-949a-e309a65e52a2)